### PR TITLE
RUN-AS-ROOT: run nexus as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,5 @@ RUN yum install -y git && \
     yum remove -y apache-maven && \
     rm /etc/yum.repos.d/epel-apache-maven.repo
 
-USER nexus
-
 CMD echo -e "crowd.server.url=$CROWD_URL\napplication.name=$CROWD_USER\napplication.password=$CROWD_PASSWORD\ncache.authentication=$CROWD_CACHE_AUTHENTICATION" > /opt/sonatype/nexus/etc/crowd.properties && \
     bin/nexus run


### PR DESCRIPTION
The Nexus home directory is owned by root

https://github.com/sonatype/docker-nexus3/blob/master/Dockerfile#L58

In order to configure Crowd at runtime, we have to write a file into Nexus' home directory.  I think that means we either need to run as root, or change the permissions of the Nexus' home directory (which are defined in the root container).  

In this PR, I suggest we run as root, but I'm open to ideas.  